### PR TITLE
Split lists of implements across multiple lines

### DIFF
--- a/src/PhpCsFixer/Config/RuleSet/Php71.php
+++ b/src/PhpCsFixer/Config/RuleSet/Php71.php
@@ -11,6 +11,11 @@ final class Php71 extends RuleSetBase
         '@PHP71Migration' => true,
         '@DoctrineAnnotation' => true,
         'blank_line_before_statement' => false,
+        'class_definition' => [
+            'multi_line_extends_each_single_line' => true,
+            'single_item_single_line' => true,
+            'single_line' => false,
+        ],
         'concat_space' => ['spacing' => 'one'],
         'doctrine_annotation_spaces' => [
             'after_argument_assignments' => true,

--- a/src/PhpCsFixer/Config/RuleSet/Php73.php
+++ b/src/PhpCsFixer/Config/RuleSet/Php73.php
@@ -11,6 +11,11 @@ final class Php73 extends RuleSetBase
         '@PHP73Migration' => true,
         '@DoctrineAnnotation' => true,
         'blank_line_before_statement' => false,
+        'class_definition' => [
+            'multi_line_extends_each_single_line' => true,
+            'single_item_single_line' => true,
+            'single_line' => false,
+        ],
         'concat_space' => ['spacing' => 'one'],
         'doctrine_annotation_spaces' => [
             'after_argument_assignments' => true,

--- a/src/PhpCsFixer/Config/RuleSet/Php74.php
+++ b/src/PhpCsFixer/Config/RuleSet/Php74.php
@@ -11,6 +11,11 @@ final class Php74 extends RuleSetBase
         '@PHP74Migration' => true,
         '@DoctrineAnnotation' => true,
         'blank_line_before_statement' => false,
+        'class_definition' => [
+            'multi_line_extends_each_single_line' => true,
+            'single_item_single_line' => true,
+            'single_line' => false,
+        ],
         'concat_space' => ['spacing' => 'one'],
         'doctrine_annotation_spaces' => [
             'after_argument_assignments' => true,

--- a/src/PhpCsFixer/Config/RuleSet/Php80.php
+++ b/src/PhpCsFixer/Config/RuleSet/Php80.php
@@ -11,6 +11,11 @@ final class Php80 extends RuleSetBase
         '@PHP80Migration' => true,
         '@DoctrineAnnotation' => true,
         'blank_line_before_statement' => false,
+        'class_definition' => [
+            'multi_line_extends_each_single_line' => true,
+            'single_item_single_line' => true,
+            'single_line' => false,
+        ],
         'concat_space' => ['spacing' => 'one'],
         'doctrine_annotation_spaces' => [
             'after_argument_assignments' => true,


### PR DESCRIPTION
## Description

In [PSR-2 section 4.1. Extends and Implements](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md#41-extends-and-implements):

> Lists of implements MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one interface per line.

This PR makes sure lists of implements are split across multiple lines. Classes that only implement one interface are not affected.

### Examples

```diff
  *     bundle = "call_to_action"
  * )
  */
-class CallToAction extends ContentBlock implements StringableInterface, CallToActionInterface
+class CallToAction extends ContentBlock implements
+    StringableInterface,
+    CallToActionInterface
 {
     public function __toString()
     {
```
