### PR TITLE
[tmp] Fix whitespace around union types separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2021-03-10
+### Changed
+- Temporary disable "binary_operator_spaces" rule for " | " [#12](https://github.com/wieni/wmcodestyle/pull/12)
+
 ## [1.4.0] - 2020-12-08
 ### Added
 - Add rulesets for PHP 7.4 & 8.0

--- a/src/PhpCsFixer/Config/RuleSet/Php80.php
+++ b/src/PhpCsFixer/Config/RuleSet/Php80.php
@@ -10,6 +10,7 @@ final class Php80 extends RuleSetBase
         '@Symfony' => true,
         '@PHP80Migration' => true,
         '@DoctrineAnnotation' => true,
+        'binary_operator_spaces' => ['operators' => ['|' => null]]
         'blank_line_before_statement' => false,
         'class_definition' => [
             'multi_line_extends_each_single_line' => true,


### PR DESCRIPTION
Disable the binary_operator_spaces ( spaces around &,|,^,<<, ... ) for | 

Until it is resolved upstream ( https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5495 )

https://www.php.net/manual/en/language.operators.bitwise.php
