### PR TITLE
Add written coding standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,7 @@ wmcodestyle
 
 ## Coding standards
 - [General](standards/GENERAL.md)
-- [Code structure](standards/CODE_STRUCTURE.md)
-- [Spaces and indentation](standards/SPACES_INDENTATION.md)
-- [Comments and docblocks](standards/COMMENTS_DOCBLOCKS.md)
-- [Models](standards/MODELS.md)
-- [Controllers](standards/CONTROLLERS.md)
-- [Event subscribers](standards/EVENT_SUBSCRIBERS.md)
-- [Drush commands](standards/DRUSH_COMMANDS.md)
-- [Publishing modules](standards/PUBLISHING_MODULES.md)
+- [Model–view–controller (and presenter)](standards/MVC.md)
 - [Git](standards/GIT.md)
 
 ## Tooling

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ wmcodestyle
 
 ## Coding standards
 - [General](standards/GENERAL.md)
+- [Drupal modules](standards/DRUPAL_MODULES.md)
 - [Model–view–controller (and presenter)](standards/MVC.md)
 - [Git](standards/GIT.md)
 

--- a/standards/DRUPAL_MODULES.md
+++ b/standards/DRUPAL_MODULES.md
@@ -24,6 +24,23 @@ to look out for when considering using contributed code:
 - **Is it worth it?** If certain functionality can be achieved with a minimal amount of custom code, it might not be 
   worth it to add a new dependency to your project.
 
+### Issues and patches
+It's not uncommon for Drupal modules or for Drupal core to have unfixed issues. Luckily, there are a lot of active 
+Drupal users, so these issues rarely go unnoticed. 
+
+Don't immediately give up when encountering an issue with a 
+contributed module: chances are the issue is already reported in the issue queue and a WIP fix is already present in the 
+form of a patch. If you add that patch to your project using 
+[`cweagans/composer-patches`](https://github.com/cweagans/composer-patches), it will automatically be applied and you'll 
+have a temporary fix while waiting for a new release.
+
+Make sure to include the issue number and title when adding a patch to your composer.json, this will make it easier to 
+remember what exactly the patch is for.
+
+In case you don't find an existing issue and/or patch, you can try to fix the issue yourself. If you do, don't forget to
+create an issue in the issue queue and leave the patch you created. Even if it's not perfect, it might be useful for
+other people encountering the same issue.
+
 ## Contributing modules
 We have the habit of creating reusable Drupal modules for functionalities we need for more than one project. Most of the
 time, we're also making them available to everyone by sharing the code on Github. Following are some things to consider 

--- a/standards/DRUPAL_MODULES.md
+++ b/standards/DRUPAL_MODULES.md
@@ -1,0 +1,82 @@
+# Modules
+> A module is a set of PHP, JavaScript, and/or CSS files that extends site features and adds functionality.
+
+_Source: [Drupal user guide](https://www.drupal.org/docs/user_guide/en/understanding-modules.html)_
+
+## Custom modules
+Every site has custom code that provides site-specific logic, tweaks the administration interface or ties together 
+functionalities from contributed packages. We usually keep all custom code in a single custom module named **wmcustom**.
+Always using the same name for your custom module gives you the advantage of making it easy to copy code between 
+projects.
+
+- https://phppackagechecklist.com/
+
+## Using contributed modules
+It's not always necessary to write custom code to add a certain functionality to your website. A well written PHP 
+package or Drupal module can save you a lot of time and may be more stable than writing new code. Here are some things 
+to look out for when considering using contributed code:
+
+- **Is the package maintained?** Look at the date of the last commit or release. Are issues being responded to?
+- **Do you think the package will stay maintained in the future?** Does the package have a lot of users? Is the 
+  maintainer actively working on the package?
+- **Is the package well-written?** Look through the code before using it. Is it following best practices? Messy code 
+  might be a red flag, but on the other hand, if it's actively being maintained it might not be a problem.
+- **Is it worth it?** If certain functionality can be achieved with a minimal amount of custom code, it might not be 
+  worth it to add a new dependency to your project.
+
+## Contributing modules
+We have the habit of creating reusable Drupal modules for functionalities we need for more than one project. Most of the
+time, we're also making them available to everyone by sharing the code on Github. Following are some things to consider 
+when working on our open source modules.
+
+### Read Me
+The README file is the landing page of your module. It should tell you what the module can be used for and how to use 
+it.  We generally have the same sections for every module:
+- A **header** with the name of the module, a one-line description and some badges with statistics
+- **Why?** What's the point of this module? What does it do? If a similar module already exists, what's the added value 
+  of this one?
+- **Installation**. A Composer command, necessary patches and/or other instructions. 
+- **How does it work?** Documentation on how to use the module. Should be divided in subheadings or moved to a separate 
+  file depending on the size.
+- **Changelog**. A link to the changelog.
+- **Security**. Information on how security issues should be reported.
+- **License**. _Distributed under [license name]_ + a link to the license file. 
+
+### Changelog
+We keep a changelog following the
+[keep a changelog 1.0.0](https://keepachangelog.com/en/1.0.0)
+convention.
+
+If the change is a result of an issue, add a link to that issue at the
+end of the line.
+```
+- Document all command options and arguments
+  ([#7](https://github.com/wieni/wmscaffold/issues/7))
+```
+
+Every repository should include a changelog in a `CHANGELOG.md` file in
+the root folder.
+
+### License
+We license our Drupal modules and other packages published on GitHub
+with the [MIT License](https://choosealicense.com/licenses/mit/). Every
+repository should include a copy of this license in a `LICENSE` file in
+the root folder.
+
+### Checklists
+#### when publishing a new module
+- [ ] Pick a good name
+- [ ] Fix the code to follow the coding standards defined in this repository 
+- [ ] Include a detailed README file, following our standards
+- [ ] Include a LICENSE file
+- [ ] Include a CHANGELOG file
+- [ ] Define all Composer dependencies in composer.json
+- [ ] Define all Drupal module dependencies in xxxx.info.yml
+- [ ] Tag the first release with [Semantic Versioning](https://semver.org) in mind
+- [ ] Submit the package on [Packagist](https://packagist.org/packages/submit)
+
+#### when updating an existing module
+- [ ] Ask for code review if you're not confident about your changes
+- [ ] Add a new entry to the CHANGELOG. Mention the tag and date if you're
+ releasing immediately, if not add it to an _Unreleased_ section.
+- [ ] Create a tag with [Semantic Versioning](https://semver.org) in mind

--- a/standards/GENERAL.md
+++ b/standards/GENERAL.md
@@ -1,0 +1,7 @@
+# General
+
+Code style must follow [PSR-1](http://www.php-fig.org/psr/psr-1/), 
+ [PSR-2](http://www.php-fig.org/psr/psr-2/) and 
+ [PSR-12](https://www.php-fig.org/psr/psr-12/). Exceptions are usually 
+ documented through php-cs-fixer rules in the rulesets included in this 
+ repository.

--- a/standards/MVC.md
+++ b/standards/MVC.md
@@ -1,0 +1,141 @@
+# Model–view–controller (and presenter)
+
+> Model–view–controller (usually known as MVC) is a software design pattern[1] commonly used for developing user 
+> interfaces that divides the related program logic into three interconnected elements. This is done to separate 
+> internal representations of information from the ways information is presented to and accepted from the user.
+
+_Source: [Wikipedia](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller)_
+
+In Drupal, there are multiple ways to building pages, of which 
+[view display modes](https://www.drupal.org/docs/8/api/entity-api/display-modes-view-modes-and-form-modes) with field 
+formatters and preprocess functions are the most common one. At Wieni, we decided to adopt a more classic, developer 
+friendly way of building pages: a combination of controller classes, model classes & templating.
+
+## Model
+> The model is responsible for managing the data of the application
+
+Every entity type has a class all loaded entities will be an instance of. Using our module 
+[`wmmodel`](https://github.com/wieni/wmmodel), we can narrow that down so we can define a class for every entity bundle.
+
+_mymodule/src/Entity/Model/Node/Page.php_
+```php
+<?php
+
+namespace Drupal\mymodule\Entity\Model\Node;
+
+use Drupal\node\Entity\Node;
+use Drupal\wmmodel\Entity\Interfaces\WmModelInterface;
+
+/**
+ * @Model(
+ *     entity_type = "node",
+ *     bundle = "page",
+ * )
+ */
+class Page extends Node implements WmModelInterface
+{
+    use WmModel;
+    
+    public function getSummary(): ?string
+    {
+        return $this->get('field_example_string')->value;
+    }
+
+}
+```
+
+### Getters and setters
+These models should only contain getters that fetch data from fields or setters that update fields. You should
+avoid calling services in models, something like that should probably be done in your controller.
+
+You should use return types as much as possible. To avoid errors, you should make return types nullable in some cases:
+- if a field is not required 
+- if a new field is added to existing entities (can be avoided by setting the value of existing entities in an update 
+  hook, executed during deployment)
+- if it's an entity reference field (we're almost never sure if the referenced entity still exists)
+
+You can use [`wmscaffold`](https://github.com/wieni/wmscaffold) to automatically generate model classes with getters
+for all entity fields.
+
+### Composition
+If you have multiple entity types/bundles having the same behaviour or fields, you can use interfaces and traits to 
+avoid copy-pasting code. An example: you need to be able to schedule the publishing of certain entities. These entity 
+models should implement `HasSchedulingInterface`, which contains methods like `getPublishDate` and `isPublished`. You'll
+also create `HasSchedulingTrait` containing implementations of the methods that are defined in that interface.
+
+## Controller
+> Accepts input and converts it to commands for the model or view.
+
+For every entity bundle with a canonical route, we define a controller class using our 
+[`wmcontroller`](https://github.com/wieni/wmcontroller) module.
+
+Controllers should be kept as small as possible. Ideally, it should only collect output of calls to services and pass 
+it along to the template. Any logic should be extracted into a service.
+
+Controller methods have no fixed names, so it's not necessary for a controller to implement a certain interface. Because 
+of that, the use of base classes can be avoided. There are two common controller base classes:
+- `Drupal\Core\Controller\ControllerBase` contains a bunch of shortcut methods to avoid having to inject commonly used 
+  dependencies. We consider using these methods bad practice, you should inject any dependencies you need yourself. To 
+  avoid temptation, you shouldn't use this class. 
+- `Drupal\wmcontroller\Controller\ControllerBase` can be used when you need the `view` method to render a Twig template,
+  but this is not necessary. You can also include the `ViewBuilderTrait` in your class instead.
+
+You should avoid creating controller base classes in custom code as well. There's almost always going to be a better 
+place to put that code: you can use traits, inject services or alter data in event subscribers. 
+[Composition over inheritance](https://en.wikipedia.org/wiki/Composition_over_inheritance)!
+
+```php
+<?php
+
+namespace Drupal\wmcustom\Controller\Node;
+
+use Drupal\wmcustom\Controller\ControllerBase;
+use Drupal\wmcustom\Entity\Node\Example;
+use Drupal\wmcustom\Service\SomeService;
+
+class ExampleController extends ControllerBase
+{
+    protected SomeService $someService;
+    
+    public function __construct(
+        SomeService $someService
+    ) {
+        $this->someService = $someService;
+    }
+    
+    public function show(Example $example)
+    {
+        $something = $this->someService->getSomething();
+        
+        return $this->view(
+            'node.example.detail', 
+            [
+                'example' => $example,
+                'something' => $something,
+            ]
+        );
+    }
+}
+
+```
+
+## View
+> The view renders presentation of the model in a particular format.
+
+The actual markup is built using Twig, the template engine included in Drupal. The controller passes arguments to a Twig 
+template and that template contains markup and other templates, included as components. These components are organised 
+in namespaces using the [Components! module](https://www.drupal.org/project/components).
+
+## Presenter
+> The presenter acts upon the model and the view. It retrieves data from repositories (the model), and formats it for display in the view.
+
+_Source: [Model-view-presenter on Wikipedia](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93presenter)_
+
+Presenters are a principle taken from *model-view-presenter*, a different software design pattern than 
+model-view-controller. We use it to transform data before displaying it. Some example use cases:
+- Concatenating names and prefixes/suffixes into a person's title 
+- Displaying a fallback image in case an image field is empty
+- Converting a set of opening hours to a format that's easier to display in Twig
+
+We facilitate presenters using our [`wmpresenter` module](https://github.com/wieni/wmpresenter). More information can be
+found in its repository.


### PR DESCRIPTION
## Description

Add written coding standards to help with onboarding.

I'm also adding docs to the following modules:
- [x] [wmpresenter](https://github.com/wieni/wmpresenter)
- [ ] [wmpage_cache](https://github.com/wieni/wmpage_cache)
- [ ] [wmtwig](https://github.com/wieni/wmtwig)

More subjects to write about:
- [ ] dependency injection
- [ ] typehinting, docblocks & comments
- [ ] hooks & event subscribers
- [x] modules & patches
- [ ] Drupal project folder structure