### PR TITLE
Add php8.1 RuleSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.0] - 2022-10-10
+### Added
+- `Php81` RuleSet.
+  - With the `BlankLineAroundClassBodyFixer`. See [PHP-CS-Fixer/#3653](https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3653)
+
+### Changed
+- **[Symfony]** Support version `^6` of Symfony
+- **[Rector]** Update Rector to 0.13
+
 ## [1.9.0] - 2021-11-16
 ### Changed
 - **[PHPStan]** Update PHPStan and related packages to 1.0
@@ -18,9 +27,9 @@ Check [UPGRADING.md](UPGRADING.md) for instructions on breaking changes.
 - **[Rector]** Include more file extensions in configs
 - **[Rector]** Include PHP 8 & PHP 8.1 setlists in configs
 - **[Rector]** Change rulesets to remove rules of existing rulesets instead of completely redefining them
-- **[Rector]** Add a minimum patch version. This makes it easier to keep track of what version our rule set overrides 
+- **[Rector]** Add a minimum patch version. This makes it easier to keep track of what version our rule set overrides
  are based on
- 
+
 ### Removed
 - Remove `mglaman/phpstan-drupal` and `phpstan/phpstan-symfony` dependencies and add recommendations to README instead.
 
@@ -105,7 +114,7 @@ Check [UPGRADING.md](UPGRADING.md) for instructions on breaking changes.
 ### Changed
 - Change repository description
 - Update README
-- Update regex of the _Implicit array creation is not allowed_ 
+- Update regex of the _Implicit array creation is not allowed_
  PHPStan rule.
 
 ## [1.1.0] - 2020-03-26

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-strict-rules": "^1.0",
         "rector/rector": "^0.13",
-        "symfony/console": "^2.8 || ^3 || ^4 || ^5",
-        "symfony/filesystem": "^3 || ^4 || ^5"
+        "symfony/console": "^2.8 || ^3 || ^4 || ^5 || ^6",
+        "symfony/filesystem": "^3 || ^4 || ^5 || ^6"
     },
     "require-dev": {
         "composer-runtime-api": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-strict-rules": "^1.0",
-        "rector/rector": "^0.12.4",
+        "rector/rector": "^0.13",
         "symfony/console": "^2.8 || ^3 || ^4 || ^5",
         "symfony/filesystem": "^3 || ^4 || ^5"
     },

--- a/src/PhpCsFixer/Config/Factory.php
+++ b/src/PhpCsFixer/Config/Factory.php
@@ -5,6 +5,7 @@ namespace Wieni\wmcodestyle\PhpCsFixer\Config;
 use PhpCsFixer\Config;
 use RuntimeException;
 use Wieni\wmcodestyle\PhpCsFixer\Config\RuleSet\RuleSetInterface;
+use Wieni\wmcodestyle\PhpCsFixer\Fixer\BlankLineAroundClassBodyFixer;
 use Wieni\wmcodestyle\PhpCsFixer\Fixer\CreateMethodOrderFixer;
 
 final class Factory
@@ -20,6 +21,7 @@ final class Factory
 
         $config->registerCustomFixers([
             new CreateMethodOrderFixer(),
+            new BlankLineAroundClassBodyFixer(),
         ]);
 
         if (getenv('WMCODESTYLE_RISKY')) {

--- a/src/PhpCsFixer/Config/RuleSet/Php81.php
+++ b/src/PhpCsFixer/Config/RuleSet/Php81.php
@@ -67,5 +67,5 @@ final class Php81 extends RuleSetBase
     ];
 
     /** @var int */
-    protected $targetPhpVersion = 80000;
+    protected $targetPhpVersion = 80100;
 }

--- a/src/PhpCsFixer/Config/RuleSet/Php81.php
+++ b/src/PhpCsFixer/Config/RuleSet/Php81.php
@@ -49,6 +49,11 @@ final class Php81 extends RuleSetBase
         'single_line_throw' => false,
         'yoda_style' => false,
         'Wieni/create_method_order' => true,
+        // Copied from https://github.com/elyby/php-code-style
+        // Leave the copyright notice intact!
+        'Wieni/blank_line_around_class_body' => [
+            'apply_to_anonymous_classes' => false,
+        ],
     ];
 
     /** @var array<string, array|bool> */

--- a/src/PhpCsFixer/Config/RuleSet/Php81.php
+++ b/src/PhpCsFixer/Config/RuleSet/Php81.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Wieni\wmcodestyle\PhpCsFixer\Config\RuleSet;
+
+final class Php81 extends RuleSetBase
+{
+    /** @var string */
+    protected $name = 'Wieni (PHP 8.1)';
+
+    /** @var array<string, array|bool> */
+    protected $rules = [
+        '@Symfony' => true,
+        '@PHP81Migration' => true,
+        '@DoctrineAnnotation' => true,
+        'binary_operator_spaces' => ['operators' => ['|' => null]],
+        'blank_line_before_statement' => false,
+        'class_definition' => [
+            'multi_line_extends_each_single_line' => true,
+            'single_item_single_line' => true,
+            'single_line' => false,
+        ],
+        'concat_space' => ['spacing' => 'one'],
+        'doctrine_annotation_spaces' => [
+            'after_argument_assignments' => true,
+            'before_argument_assignments' => true,
+        ],
+        'explicit_indirect_variable' => true,
+        'global_namespace_import' => false,
+        'increment_style' => ['style' => 'post'],
+        'no_superfluous_phpdoc_tags' => [
+            'allow_mixed' => true,
+            'remove_inheritdoc' => true,
+        ],
+        'no_useless_return' => true,
+        'nullable_type_declaration_for_default_null_value' => true,
+        'operator_linebreak' => true,
+        'ordered_class_elements' => true,
+        'phpdoc_align' => false,
+        'phpdoc_annotation_without_dot' => false,
+        'phpdoc_line_span' => [
+            'const' => 'single',
+            'method' => 'single',
+            'property' => 'single',
+        ],
+        'phpdoc_separation' => false,
+        'phpdoc_summary' => false,
+        'phpdoc_to_comment' => false,
+        'simplified_if_return' => true,
+        'single_line_throw' => false,
+        'yoda_style' => false,
+        'Wieni/create_method_order' => true,
+    ];
+
+    /** @var array<string, array|bool> */
+    protected $riskyRules = [
+        '@Symfony:risky' => true,
+        '@PHP81Migration:risky' => true,
+        'comment_to_phpdoc' => true,
+        'declare_strict_types' => false,
+        'native_constant_invocation' => false,
+        'native_function_invocation' => false,
+    ];
+
+    /** @var int */
+    protected $targetPhpVersion = 80000;
+}

--- a/src/PhpCsFixer/Fixer/BlankLineAroundClassBodyFixer.php
+++ b/src/PhpCsFixer/Fixer/BlankLineAroundClassBodyFixer.php
@@ -1,0 +1,158 @@
+<?php
+declare(strict_types=1);
+
+namespace Wieni\wmcodestyle\PhpCsFixer\Fixer;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\ConfigurableFixerInterface;
+use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Preg;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\Tokenizer\TokensAnalyzer;
+
+/**
+ * This is copy of the PR https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3688
+ *
+ * @author ErickSkrauch <erickskrauch@ely.by>
+ */
+final class BlankLineAroundClassBodyFixer extends AbstractFixer implements ConfigurableFixerInterface, WhitespacesAwareFixerInterface {
+
+    public function getName(): string
+    {
+        return implode('/', ['Wieni', parent::getName()]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition(): FixerDefinitionInterface {
+        return new FixerDefinition(
+            'Ensure that class body contains one blank line after class definition and before its end.',
+            [
+                new CodeSample(
+                    '<?php
+class Sample
+{
+    protected function foo()
+    {
+    }
+}
+'
+                ),
+                new CodeSample(
+                    '<?php
+new class extends Foo {
+
+    protected function foo()
+    {
+    }
+
+};
+',
+                    ['apply_to_anonymous_classes' => false]
+                ),
+                new CodeSample(
+                    '<?php
+new class extends Foo {
+    protected function foo()
+    {
+    }
+};
+',
+                    ['apply_to_anonymous_classes' => true]
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority(): int {
+        // should be run after the BracesFixer
+        return -26;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens): bool {
+        return $tokens->isAnyTokenKindsFound(Token::getClassyTokenKinds());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void {
+        $analyzer = new TokensAnalyzer($tokens);
+        foreach ($tokens as $index => $token) {
+            if (!$token->isClassy()) {
+                continue;
+            }
+
+            $countLines = $this->configuration['blank_lines_count'];
+            if (!$this->configuration['apply_to_anonymous_classes'] && $analyzer->isAnonymousClass($index)) {
+                $countLines = 0;
+            }
+
+            $startBraceIndex = $tokens->getNextTokenOfKind($index, ['{']);
+            if ($tokens[$startBraceIndex + 1]->isWhitespace()) {
+                $nextStatementIndex = $tokens->getNextMeaningfulToken($startBraceIndex);
+                // Traits should be placed right after a class opening brace,
+                if ($tokens[$nextStatementIndex]->getContent() !== 'use') {
+                    $this->fixBlankLines($tokens, $startBraceIndex + 1, $countLines);
+                }
+            }
+
+            $endBraceIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $startBraceIndex);
+            if ($tokens[$endBraceIndex - 1]->isWhitespace()) {
+                $this->fixBlankLines($tokens, $endBraceIndex - 1, $countLines);
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createConfigurationDefinition(): FixerConfigurationResolverInterface {
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('blank_lines_count', 'adjusts an amount of the blank lines.'))
+                ->setAllowedTypes(['int'])
+                ->setDefault(1)
+                ->getOption(),
+            (new FixerOptionBuilder('apply_to_anonymous_classes', 'whether this fixer should be applied to anonymous classes.'))
+                ->setAllowedTypes(['bool'])
+                ->setDefault(true)
+                ->getOption(),
+        ]);
+    }
+
+    /**
+     * Cleanup a whitespace token.
+     *
+     * @param Tokens $tokens
+     * @param int    $index
+     * @param int    $countLines
+     */
+    private function fixBlankLines(Tokens $tokens, $index, $countLines): void {
+        $content = $tokens[$index]->getContent();
+        // Apply fix only in the case when the count lines do not equals to expected
+        if (substr_count($content, "\n") === $countLines + 1) {
+            return;
+        }
+
+        // The final bit of the whitespace must be the next statement's indentation
+        Preg::matchAll('/[^\n\r]+[\r\n]*/', $content, $matches);
+        $lines = $matches[0];
+        $eol = $this->whitespacesConfig->getLineEnding();
+        $tokens[$index] = new Token([T_WHITESPACE, str_repeat($eol, $countLines + 1) . end($lines)]);
+    }
+
+}


### PR DESCRIPTION
## Description

This adds a `Php81` ruleset. And updates the `composer.json` to be compatible with Symfony `^6`.

### Documentation

```diff
<?php

use Wieni\wmcodestyle\PhpCsFixer\Config\Factory;
- use Wieni\wmcodestyle\PhpCsFixer\Config\RuleSet\Php80;
+ use Wieni\wmcodestyle\PhpCsFixer\Config\RuleSet\Php81;

$config = Factory::fromRuleSet(
-    new Php80,
+    new Php81,
);

$config->getFinder()
    ->in(__DIR__)
    ->name('/\.(php|module|inc|install|test|profile|theme)$/')
    ->exclude([
        'drush/contrib',
        'public/core',
        'public/modules/contrib',
        'public/sites/default/files/php',
        'public/themes/contrib',
        'public/profiles/contrib',
        'public/libraries',
    ])
    ->notPath('/(public|web)\/(index|update)\.php/');

$config->setCacheFile(__DIR__ . '/.php_cs.cache');

return $config;
```
